### PR TITLE
cli: rework version flag handling

### DIFF
--- a/src/DynamicKeepalived/CLI.hs
+++ b/src/DynamicKeepalived/CLI.hs
@@ -3,15 +3,10 @@ module DynamicKeepalived.CLI (
     , parser
     ) where
 
-import Options.Applicative
+import Options.Applicative (Parser)
 
-data Options = Options { optionsVersion :: Bool
-                       }
+data Options = Options
   deriving (Show, Eq)
 
 parser :: Parser Options
-parser =  Options
-      <$> switch
-          ( long "version"
-         <> short 'v'
-         <> help "Display the version number" )
+parser = pure Options

--- a/src/DynamicKeepalived/Main.hs
+++ b/src/DynamicKeepalived/Main.hs
@@ -2,26 +2,27 @@ module DynamicKeepalived.Main (
       main
     ) where
 
-import Control.Monad (when)
 import Data.Version (showVersion)
-import System.Exit (exitSuccess)
 
 import Options.Applicative (
       (<**>)
     , ParseError(ShowHelpText)
-    , abortOption, execParser, fullDesc, help, hidden, info, long, short)
+    , abortOption, execParser, fullDesc, help, hidden, info, infoOption, long, short)
 
 import qualified DynamicKeepalived.CLI as CLI
 
 import qualified Paths_dynamic_keepalived
 
 main :: IO ()
-main = execParser opts >>= \options -> do
-    when (CLI.optionsVersion options) $ do
-        putStrLn $ "dynamic-keepalived v" ++ showVersion Paths_dynamic_keepalived.version
-        exitSuccess
+main = execParser opts >>= \CLI.Options -> return ()
   where
-    opts = info (CLI.parser <**> helper) fullDesc
+    opts = info (CLI.parser <**> version <**> helper) fullDesc
+    version = infoOption versionMessage $ mconcat [ long "version"
+                                                  , short 'v'
+                                                  , help "Display the version number"
+                                                  , hidden
+                                                  ]
+    versionMessage = "dynamic-keepalived v" ++ showVersion Paths_dynamic_keepalived.version
     helper = abortOption ShowHelpText $ mconcat [ long "help"
                                                 , short 'h'
                                                 , help "Display this help message"


### PR DESCRIPTION
When treating `--version` as a 'normal' flag, adding required arguments
later will not work, since they would be... required, even when passing
only the `-v`/`--version` flag.

As such, treating it as a short-circuiting flag a-la `--help`.

See: 2b0a7bd652759b6c4042d144fa231edf88ae06c2