### PR TITLE
lib: add a logging DSL monad transformer

### DIFF
--- a/dynamic-keepalived.cabal
+++ b/dynamic-keepalived.cabal
@@ -29,15 +29,19 @@ Library dynamic-keepalived-internal
   Exposed-Modules:     DynamicKeepalived
                      , DynamicKeepalived.DSL
                      , DynamicKeepalived.DSL.IO
+                     , DynamicKeepalived.DSL.Logging
                      , DynamicKeepalived.Dhall
   Build-Depends:       base >=4.11 && <5
                      , atomic-write >=0.2.0.7 && <0.3
                      , bytestring >=0.10.8.2 && <0.11
                      , contravariant >=1.5.2 && <1.6
                      , dhall >=1.31.0 && <1.32
+                     , di-df1 >=1.2 && <1.3
+                     , di-monad >=1.3.1 && <1.4
                      , dns >=4.0.1 && <4.1
                      , exceptions >=0.10.0 && <0.11
                      , iproute >=1.7.9 && <1.8
+                     , text >=1.2 && <1.3
                      , transformers >=0.5.5.0 && <0.6
                      , unix >=2.7.2.2 && <2.8
   Hs-Source-Dirs:      lib
@@ -61,9 +65,13 @@ Test-Suite test-dynamic-keepalived
   Other-Modules:       DynamicKeepalived.DSL.Interpreter
                      , DynamicKeepalived.Test
                      , DynamicKeepalived.DSL.IO.Test
+                     , DynamicKeepalived.DSL.Logging.Test
                      , DynamicKeepalived.Dhall.Test
   Build-Depends:       base
+                     , bytestring
                      , dhall
+                     , di-core
+                     , di-monad
                      , dns
                      , exceptions
                      , hspec >=2.7.1 && <2.8
@@ -71,6 +79,7 @@ Test-Suite test-dynamic-keepalived
                      , lens-family-core >=2.1.0 && <2.2
                      , mtl >=2.2.2 && <2.3
                      , process >=1.6.3.0 && <1.7
+                     , stm >=2.4.5.1 && <2.6
                      , temporary >=1.3 && <1.4
                      , transformers
                      , unix

--- a/lib/DynamicKeepalived/DSL.hs
+++ b/lib/DynamicKeepalived/DSL.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module DynamicKeepalived.DSL (
@@ -17,9 +18,16 @@ import Data.IP (IP)
 
 import Network.DNS (Domain)
 
+import Di.Df1 (ToValue(..))
+
 data RecordType = A
                 | AAAA
   deriving (Show, Eq, Enum, Bounded)
+
+instance ToValue RecordType where
+    value v = case v of
+        A -> "A"
+        AAAA -> "AAAA"
 
 class Monad m => MonadDSL m where
     resolveDNS :: RecordType -> Domain -> m [IP]

--- a/lib/DynamicKeepalived/DSL/IO.hs
+++ b/lib/DynamicKeepalived/DSL/IO.hs
@@ -20,6 +20,8 @@ import Network.DNS (ResolvSeed, withResolver, lookupA, lookupAAAA)
 
 import System.AtomicWrite.Writer.LazyByteString (atomicWriteFile)
 
+import Di.Monad (MonadDi)
+
 import DynamicKeepalived.DSL (MonadDSL(..), RecordType(..), ByteString)
 
 data IOTEnv = IOTEnv { iotEnvConfigPath :: FilePath
@@ -29,7 +31,7 @@ data IOTEnv = IOTEnv { iotEnvConfigPath :: FilePath
                      }
 
 newtype IOT m a = IOT { unIOT :: ReaderT IOTEnv m a }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadCatch, MonadThrow, MonadMask)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadCatch, MonadThrow, MonadMask, MonadDi level path message)
 
 runIO :: ResolvSeed -> ([IP] -> ByteString) -> FilePath -> FilePath -> IOT m a -> m a
 runIO resolvSeed renderConfig' configPath pidPath act =

--- a/lib/DynamicKeepalived/DSL/Logging.hs
+++ b/lib/DynamicKeepalived/DSL/Logging.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module DynamicKeepalived.DSL.Logging (
+      runLoggingT
+    ) where
+
+import Control.Monad (forM_)
+import Control.Monad.IO.Class (MonadIO)
+
+import Control.Monad.Catch (MonadCatch, MonadThrow, MonadMask)
+
+import Control.Monad.Trans.Class (MonadTrans, lift)
+import Control.Monad.Trans.Identity (IdentityT, runIdentityT)
+
+import Data.Text.Encoding (decodeUtf8)
+
+import Di.Monad (MonadDi)
+import Di.Df1 (ToValue(..), Message, Level, Path)
+import Di.Df1.Monad (attr, push, debug_, info_, notice_)
+
+import DynamicKeepalived.DSL (MonadDSL(..), Domain, IP)
+
+newtype LoggingT m a = LoggingT { unLoggingT :: IdentityT m a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadCatch, MonadThrow, MonadMask, MonadDi level path message)
+
+runLoggingT :: LoggingT m a -> m a
+runLoggingT = runIdentityT . unLoggingT
+
+newtype IPV = IPV { unIPV :: IP }
+
+instance ToValue IPV where
+    value = value . show . unIPV
+
+newtype DomainV = DomainV { unDomainV :: Domain }
+
+instance ToValue DomainV where
+    value = value . decodeUtf8 . unDomainV
+
+instance (MonadDSL m, MonadDi Level Path Message m) => MonadDSL (LoggingT m) where
+    resolveDNS r d = push "resolve-dns" $ attr "record-type" r $ attr "domain" (DomainV d) $ do
+        info_ "Resolving DNS record"
+        res <- lift $ resolveDNS r d
+        push "result" $ attr "count" (length res) $ do
+            debug_ "DNS resolution returned"
+            if not (null res)
+               then forM_ res $ \ip -> attr "address" (IPV ip) $ debug_ "Resolved domain"
+               else notice_ "No addresses returned"
+        return res
+    renderConfig l = push "render-config" $ attr "count" (length l) $ do
+        info_ "Rendering configuration"
+        c <- lift $ renderConfig l
+        debug_ "Configuration rendering completed"
+        return c
+    writeConfig c = push "write-config" $ do
+        info_ "Writing configuration"
+        lift $ writeConfig c
+        debug_ "Configuration written"
+    reloadKeepalived = push "reload-keepalived" $ do
+        info_ "Reloading keepalived"
+        lift reloadKeepalived
+        debug_ "Keepalived reloaded"
+    sleep l = push "sleep" $ attr "time" l $ do
+        info_ "Sleeping"
+        lift $ sleep l
+        debug_ "Waking up again"

--- a/test/DynamicKeepalived/DSL/Interpreter.hs
+++ b/test/DynamicKeepalived/DSL/Interpreter.hs
@@ -15,6 +15,8 @@ import Control.Monad.Writer.Class (MonadWriter, tell)
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Reader (ReaderT, runReaderT, reader)
 
+import Di.Monad (MonadDi)
+
 import DynamicKeepalived.DSL (MonadDSL(..), RecordType, ByteString, Domain, IP)
 
 data Interpreter m = Interpreter { interpretResolveDNS :: RecordType -> Domain -> m [IP]
@@ -60,7 +62,7 @@ tracer = Interpreter { interpretResolveDNS = \t d -> tell' (ResolveDNS t d) $> m
 
 
 newtype InterpreterT m a = InterpreterT { unInterpreterT :: ReaderT (Interpreter m) m a }
-  deriving (Functor, Applicative, Monad)
+  deriving (Functor, Applicative, Monad, MonadDi level path message)
 
 instance MonadTrans InterpreterT where
     lift = InterpreterT . lift

--- a/test/DynamicKeepalived/DSL/Logging/Test.hs
+++ b/test/DynamicKeepalived/DSL/Logging/Test.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module DynamicKeepalived.DSL.Logging.Test (
+      spec
+    ) where
+
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TQueue (newTQueueIO, writeTQueue, flushTQueue)
+
+import qualified Di.Core
+import Di.Monad (runDiT)
+
+import Test.Hspec (Spec, describe, it, shouldReturn, shouldNotReturn)
+
+import DynamicKeepalived (Settings(..), iteration, initialState)
+import DynamicKeepalived.DSL (RecordType(..))
+import DynamicKeepalived.DSL.IO (runIO)
+import DynamicKeepalived.DSL.Logging (runLoggingT)
+
+import DynamicKeepalived.DSL.Interpreter (runInterpreterT)
+
+spec :: Spec
+spec =
+    describe "runLoggingT" $ do
+        it "compiles with runIO" $ do
+            let act = Di.Core.new (const $ return ()) $ \di -> runDiT di $
+                        runIO undefined undefined undefined undefined $ runLoggingT $ return ()
+            act `shouldReturn` ()
+
+        it "adds logging" $ do
+            queue <- newTQueueIO
+            let handle = atomically . writeTQueue queue
+
+            _ <- Di.Core.new handle $ \di -> runDiT di $
+                flip runInterpreterT mempty $ runLoggingT $ iteration (Settings 10 A "nicolast.be") initialState
+
+            atomically (flushTQueue queue) `shouldNotReturn` []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,10 +6,12 @@ import Test.Hspec (hspec, describe)
 
 import qualified DynamicKeepalived.Test
 import qualified DynamicKeepalived.DSL.IO.Test
+import qualified DynamicKeepalived.DSL.Logging.Test
 import qualified DynamicKeepalived.Dhall.Test
 
 main :: IO ()
 main = hspec $ do
     describe "DynamicKeepalived" DynamicKeepalived.Test.spec
     describe "DynamicKeepalived.DSL.IO" DynamicKeepalived.DSL.IO.Test.spec
+    describe "DynamicKeepalived.DSL.Logging" DynamicKeepalived.DSL.Logging.Test.spec
     describe "DynamicKeepalived.Dhall" DynamicKeepalived.Dhall.Test.spec


### PR DESCRIPTION
This transformer adds logging information around every DSL operation,
wihch is lifted to the underlying monad.