### PR TITLE
lib: reduce `lift`ing in monad towers

### DIFF
--- a/lib/DynamicKeepalived/DSL.hs
+++ b/lib/DynamicKeepalived/DSL.hs
@@ -11,6 +11,8 @@ module DynamicKeepalived.DSL (
     ) where
 
 import Control.Monad.Trans.Class (MonadTrans, lift)
+import Control.Monad.Trans.Identity (IdentityT)
+import Control.Monad.Trans.Reader (ReaderT)
 
 import Data.ByteString.Lazy (ByteString)
 
@@ -46,3 +48,6 @@ class Monad m => MonadDSL m where
     reloadKeepalived = lift reloadKeepalived
     default sleep :: (MonadTrans t, MonadDSL m', m ~ t m') => Word -> m ()
     sleep = lift . sleep
+
+instance MonadDSL m => MonadDSL (IdentityT m)
+instance MonadDSL m => MonadDSL (ReaderT e m)

--- a/lib/DynamicKeepalived/DSL/Logging.hs
+++ b/lib/DynamicKeepalived/DSL/Logging.hs
@@ -11,7 +11,7 @@ import Control.Monad.IO.Class (MonadIO)
 
 import Control.Monad.Catch (MonadCatch, MonadThrow, MonadMask)
 
-import Control.Monad.Trans.Class (MonadTrans, lift)
+import Control.Monad.Trans.Class (MonadTrans)
 import Control.Monad.Trans.Identity (IdentityT, runIdentityT)
 
 import Data.Text.Encoding (decodeUtf8)
@@ -41,7 +41,7 @@ instance ToValue DomainV where
 instance (MonadDSL m, MonadDi Level Path Message m) => MonadDSL (LoggingT m) where
     resolveDNS r d = LoggingT $ push "resolve-dns" $ attr "record-type" r $ attr "domain" (DomainV d) $ do
         info_ "Resolving DNS record"
-        res <- lift $ resolveDNS r d
+        res <- resolveDNS r d
         push "result" $ attr "count" (length res) $ do
             debug_ "DNS resolution returned"
             if not (null res)
@@ -50,18 +50,18 @@ instance (MonadDSL m, MonadDi Level Path Message m) => MonadDSL (LoggingT m) whe
         return res
     renderConfig l = LoggingT $ push "render-config" $ attr "count" (length l) $ do
         info_ "Rendering configuration"
-        c <- lift $ renderConfig l
+        c <- renderConfig l
         debug_ "Configuration rendering completed"
         return c
     writeConfig c = LoggingT $ push "write-config" $ do
         info_ "Writing configuration"
-        lift $ writeConfig c
+        writeConfig c
         debug_ "Configuration written"
     reloadKeepalived = LoggingT $ push "reload-keepalived" $ do
         info_ "Reloading keepalived"
-        lift reloadKeepalived
+        reloadKeepalived
         debug_ "Keepalived reloaded"
     sleep l = LoggingT $ push "sleep" $ attr "time" l $ do
         info_ "Sleeping"
-        lift $ sleep l
+        sleep l
         debug_ "Waking up again"

--- a/lib/DynamicKeepalived/DSL/Logging.hs
+++ b/lib/DynamicKeepalived/DSL/Logging.hs
@@ -39,7 +39,7 @@ instance ToValue DomainV where
     value = value . decodeUtf8 . unDomainV
 
 instance (MonadDSL m, MonadDi Level Path Message m) => MonadDSL (LoggingT m) where
-    resolveDNS r d = push "resolve-dns" $ attr "record-type" r $ attr "domain" (DomainV d) $ do
+    resolveDNS r d = LoggingT $ push "resolve-dns" $ attr "record-type" r $ attr "domain" (DomainV d) $ do
         info_ "Resolving DNS record"
         res <- lift $ resolveDNS r d
         push "result" $ attr "count" (length res) $ do
@@ -48,20 +48,20 @@ instance (MonadDSL m, MonadDi Level Path Message m) => MonadDSL (LoggingT m) whe
                then forM_ res $ \ip -> attr "address" (IPV ip) $ debug_ "Resolved domain"
                else notice_ "No addresses returned"
         return res
-    renderConfig l = push "render-config" $ attr "count" (length l) $ do
+    renderConfig l = LoggingT $ push "render-config" $ attr "count" (length l) $ do
         info_ "Rendering configuration"
         c <- lift $ renderConfig l
         debug_ "Configuration rendering completed"
         return c
-    writeConfig c = push "write-config" $ do
+    writeConfig c = LoggingT $ push "write-config" $ do
         info_ "Writing configuration"
         lift $ writeConfig c
         debug_ "Configuration written"
-    reloadKeepalived = push "reload-keepalived" $ do
+    reloadKeepalived = LoggingT $ push "reload-keepalived" $ do
         info_ "Reloading keepalived"
         lift reloadKeepalived
         debug_ "Keepalived reloaded"
-    sleep l = push "sleep" $ attr "time" l $ do
+    sleep l = LoggingT $ push "sleep" $ attr "time" l $ do
         info_ "Sleeping"
         lift $ sleep l
         debug_ "Waking up again"


### PR DESCRIPTION
Instead of `lift`ing in the `MonadDSL` implementations of wrappers
around `IdentityT` and `ReaderT`, just provide a `MonadDSL` instance for
those (using the generic `MonadTrans` implementations as provided in the
class definition), and be done with it.